### PR TITLE
PSR1 recommends that each class must be in a namespace of at least on…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
         "psr-4": {
             "CupsGenerator\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     }
 }

--- a/tests/CupsTest.php
+++ b/tests/CupsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use CupsGenerator\Cups;
 
 /**
@@ -7,7 +9,7 @@ use CupsGenerator\Cups;
  *
  * @link https://es.wikipedia.org/wiki/C%C3%B3digo_Unificado_de_Punto_de_Suministro
  */
-class CupsTest extends PHPUnit_Framework_TestCase
+class CupsTest extends \PHPUnit_Framework_TestCase
 {
     public function testHasNormalLength()
     {


### PR DESCRIPTION
…e level to avoid collisions.